### PR TITLE
使用cocoa pods安装时会出错，修改了podspec文件

### DIFF
--- a/GYHttpMock.podspec
+++ b/GYHttpMock.podspec
@@ -9,7 +9,24 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/hypoyao/GYHttpMock.git", :tag => "1.0.0" }
   s.platform     = :ios, '7.0'
   s.requires_arc = true
-  s.source_files = '**/*.{h,m}'
+  s.source_files = 'GYHttpMock/*.{h,m}'
+
+  s.subspec "Request" do |ss|
+    ss.source_files = "GYHttpMock/Request/*.{h,m}"
+  end
+
+  s.subspec "Response" do |ss|
+    ss.source_files = "GYHttpMock/Response/*.{h,m}"
+  end
+
+  s.subspec "Hooks" do |ss|
+    ss.source_files = "GYHttpMock/Hooks/*.{h,m}"
+  end
+
+  s.subspec "Categories" do |ss|
+    ss.source_files = "GYHttpMock/Categories/*.{h,m}"
+  end
+
   s.public_header_files = [
     'GYHttpMock.h',
     'GYMatcher.h',

--- a/GYHttpMock.podspec
+++ b/GYHttpMock.podspec
@@ -9,22 +9,22 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/hypoyao/GYHttpMock.git", :tag => "1.0.0" }
   s.platform     = :ios, '7.0'
   s.requires_arc = true
-  s.source_files = 'GYHttpMock/*.{h,m}'
+  s.source_files = '**/*.{h,m}'
 
   s.subspec "Request" do |ss|
-    ss.source_files = "GYHttpMock/Request/*.{h,m}"
+    ss.source_files = "**/Request/*.{h,m}"
   end
 
   s.subspec "Response" do |ss|
-    ss.source_files = "GYHttpMock/Response/*.{h,m}"
+    ss.source_files = "**/Response/*.{h,m}"
   end
 
   s.subspec "Hooks" do |ss|
-    ss.source_files = "GYHttpMock/Hooks/*.{h,m}"
+    ss.source_files = "**/Hooks/*.{h,m}"
   end
 
   s.subspec "Categories" do |ss|
-    ss.source_files = "GYHttpMock/Categories/*.{h,m}"
+    ss.source_files = "**/Categories/*.{h,m}"
   end
 
   s.frameworks = 'Foundation','CFNetwork'

--- a/GYHttpMock.podspec
+++ b/GYHttpMock.podspec
@@ -9,22 +9,22 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/hypoyao/GYHttpMock.git", :tag => "1.0.0" }
   s.platform     = :ios, '7.0'
   s.requires_arc = true
-  s.source_files = '*.{h,m}'
+  s.source_files = './*.{h,m}'
 
   s.subspec "Request" do |ss|
-    ss.source_files = "Request/*.{h,m}"
+    ss.source_files = "./Request/*.{h,m}"
   end
 
   s.subspec "Response" do |ss|
-    ss.source_files = "Response/*.{h,m}"
+    ss.source_files = "./Response/*.{h,m}"
   end
 
   s.subspec "Hooks" do |ss|
-    ss.source_files = "Hooks/*.{h,m}"
+    ss.source_files = "./Hooks/*.{h,m}"
   end
 
   s.subspec "Categories" do |ss|
-    ss.source_files = "Categories/*.{h,m}"
+    ss.source_files = "./Categories/*.{h,m}"
   end
 
   s.frameworks = 'Foundation','CFNetwork'

--- a/GYHttpMock.podspec
+++ b/GYHttpMock.podspec
@@ -27,21 +27,6 @@ Pod::Spec.new do |s|
     ss.source_files = "GYHttpMock/Categories/*.{h,m}"
   end
 
-  s.public_header_files = [
-    'GYHttpMock.h',
-    'GYMatcher.h',
-    'GYNSURLProtocol.h',
-    'Categories/NSString+mock.h',
-    'Categories/NSURLRequest+GYURLRequestProtocol.h',
-    'Hooks/GYHttpClientHook.h',
-    'Hooks/GYURLHook.h',
-    'Hooks/GYNSURLSessionHook.h',
-    'Request/GYSubRequest.h',
-    'Request/GYMockRequest.h',
-    'Request/GYMockRequestDSL.h',
-    'Response/GYMockResponse.h',
-    'Response/GYMockResponseDSL.h',
-  ]
   s.frameworks = 'Foundation','CFNetwork'
 
 end

--- a/GYHttpMock.podspec
+++ b/GYHttpMock.podspec
@@ -9,22 +9,22 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/hypoyao/GYHttpMock.git", :tag => "1.0.0" }
   s.platform     = :ios, '7.0'
   s.requires_arc = true
-  s.source_files = '**/*.{h,m}'
+  s.source_files = '*.{h,m}'
 
   s.subspec "Request" do |ss|
-    ss.source_files = "**/Request/*.{h,m}"
+    ss.source_files = "Request/*.{h,m}"
   end
 
   s.subspec "Response" do |ss|
-    ss.source_files = "**/Response/*.{h,m}"
+    ss.source_files = "Response/*.{h,m}"
   end
 
   s.subspec "Hooks" do |ss|
-    ss.source_files = "**/Hooks/*.{h,m}"
+    ss.source_files = "Hooks/*.{h,m}"
   end
 
   s.subspec "Categories" do |ss|
-    ss.source_files = "**/Categories/*.{h,m}"
+    ss.source_files = "Categories/*.{h,m}"
   end
 
   s.frameworks = 'Foundation','CFNetwork'

--- a/GYHttpMock.podspec
+++ b/GYHttpMock.podspec
@@ -9,22 +9,22 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/hypoyao/GYHttpMock.git", :tag => "1.0.0" }
   s.platform     = :ios, '7.0'
   s.requires_arc = true
-  s.source_files = './*.{h,m}'
+  s.source_files = '**/*.{h,m}'
 
   s.subspec "Request" do |ss|
-    ss.source_files = "./Request/*.{h,m}"
+    ss.source_files = "**/Request/*.{h,m}"
   end
 
   s.subspec "Response" do |ss|
-    ss.source_files = "./Response/*.{h,m}"
+    ss.source_files = "**/Response/*.{h,m}"
   end
 
   s.subspec "Hooks" do |ss|
-    ss.source_files = "./Hooks/*.{h,m}"
+    ss.source_files = "**/Hooks/*.{h,m}"
   end
 
   s.subspec "Categories" do |ss|
-    ss.source_files = "./Categories/*.{h,m}"
+    ss.source_files = "**/Categories/*.{h,m}"
   end
 
   s.frameworks = 'Foundation','CFNetwork'


### PR DESCRIPTION
cocoa pods安装后编译时会找不到GYMockRequest类，该类的头文件在target membership中是project（应该是public），修改pod spec文件后解决此问题
